### PR TITLE
no longer verify ssl certs

### DIFF
--- a/lib/API.php
+++ b/lib/API.php
@@ -141,6 +141,7 @@ class API
                 );
         }
 
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $httpheaders);
 


### PR DESCRIPTION
fixes an issue with certain PHP configurations where there are no default trusted CA's
