### PR TITLE
Have the batch method return a value besides null on success.

### DIFF
--- a/README.md
+++ b/README.md
@@ -786,14 +786,32 @@ Execute all commands at once by calling `execute()` on the object.
 ```php
 $batch_api = api->start_batch();
 for($i = 0; $i < 10; $i++) {
-    $batch_api->create_customer('us@sendwithus.com',
+    $result = $batch_api->create_customer('us@sendwithus.com',
         array('name' => 'Sendwithus'));
+    // $result->success == true && $result->status == 'Batched'
 }
 $result = $batch_api->execute();
 
 // $result will be an array of responses for each command executed.
 
 ```
+
+### Canceling Batch Request
+Sometimes it is necessary to cancel all the api requests that have been batched, but not yet sent.
+To do that, use `cancel()`:
+
+### Example
+```php
+$batch_api = api->start_batch();
+for($i = 0; $i < 10; $i++) {
+    $batch_api->create_customer('us@sendwithus.com',
+        array('name' => 'Sendwithus'));
+}
+$result = $batch_api->cancel();
+// $result->success == true && $result->status == 'Canceled'
+```
+
+Once you have canceled a batch, you can continue to use the batch to make more requests.
 
 ## Tests
 

--- a/lib/API.php
+++ b/lib/API.php
@@ -732,6 +732,7 @@ class API {
             error_log(sprintf("path: %s\r\n", $path));
         }
 
+        $code = null;
         try {
             $result = curl_exec($ch);
             $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -787,6 +788,11 @@ class BatchAPI extends API {
         }
 
         $this->commands[] = $command;
+
+        return (object) array(
+            'status' => 'Batched',
+            'success' => true,
+        );
     }
 
     /**
@@ -827,6 +833,8 @@ class BatchAPI extends API {
             error_log(sprintf("path: %s\r\n", $path));
         }
 
+        $code = null;
+
         try {
             $result = curl_exec($ch);
             $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -853,6 +861,21 @@ class BatchAPI extends API {
         $this->commands = array();
 
         return $response;
+    }
+
+    /**
+     * Cancel any pending batched commands to be sent.
+     *
+     * @return object
+     */
+    public function cancel() {
+        $this->commands = array();
+        return (object) array(
+            'code' => 0,  // Use 0 because we didn't even talk to the server.
+            'status' => 'Canceled',
+            'success' => true,
+            'exception' => null
+        );
     }
 
     public function command_length() {


### PR DESCRIPTION
## Batch API
### execute()
- Make the return value consistent with the API.

### cancel()
- Added a cancel function to clear the batched api requests.