### PR TITLE
Fix/remove deprecated api calls

### DIFF
--- a/lib/API.php
+++ b/lib/API.php
@@ -529,30 +529,6 @@ class API {
     }
 
     /**
-     * List customers on drip campaign
-     *
-     * @param string $drip_campaign_id id of drip campaign
-     * @return array API response object
-     */
-    public function list_drip_campaign_customers($drip_campaign_id){
-        $endpoint = "drip_campaigns/" . $drip_campaign_id . "/customers";
-
-        return $this->api_request($endpoint, self::HTTP_GET);
-    }
-
-    /**
-     * List customers on drip campaign step
-     *
-     * @param string $drip_campaign_id id of drip campaign
-     * @param string $drip_step_id id of drip campaign step
-     * @return array API response object
-     */
-    public function list_drip_campaign_step_customers($drip_campaign_id, $drip_step_id){
-        $endpoint = "drip_campaigns/" . $drip_campaign_id . "/steps/" . $drip_step_id . "/customers";
-
-        return $this->api_request($endpoint, self::HTTP_GET);
-    }
-    /**
      * Start on drip campaign
      *
      * The additional optional parameters for $args are as follows:

--- a/lib/API.php
+++ b/lib/API.php
@@ -22,7 +22,7 @@ class API {
     protected $API_VERSION = '1';
     protected $API_HEADER_KEY = 'X-SWU-API-KEY';
     protected $API_HEADER_CLIENT = 'X-SWU-API-CLIENT';
-    protected $API_CLIENT_VERSION = "2.11.0";
+    protected $API_CLIENT_VERSION = "2.12.0";
     protected $API_CLIENT_STUB = "php-%s";
 
     protected $DEBUG = false;

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -526,22 +526,6 @@ class APITestCase extends PHPUnit_Framework_TestCase
         print 'Test add to false drip campaigns';
     }
 
-    public function testListCustomersOnCampaign(){
-        $r = $this->api->list_drip_campaign_customers($this->enabled_drip_campaign_id);
-
-        $this->assertEquals($r->id, $this->enabled_drip_campaign_id);
-
-        print 'Test list customers on drip campaign';
-    }
-
-    public function testListCustomersOnCampaignStep(){
-        $r = $this->api->list_drip_campaign_step_customers($this->enabled_drip_campaign_id, $this->enabled_drip_campaign_step_id);
-
-        $this->assertEquals($r->id, $this->enabled_drip_campaign_step_id);
-
-        print 'Test list customers on a drip campaign step';
-    }
-
     public function testRemoveOnDripCampaign(){
         $r = $this->api->remove_from_drip_campaign('person@example.com',$this->enabled_drip_campaign_id);
         $this->assertSuccess($r);


### PR DESCRIPTION
This removes two methods that are no longer supported by sendwithus'
API:

- list_drip_campaign_customers
- list_drip_campaign_step_customers