### PR TITLE
Deprecate Conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,49 +680,6 @@ Example
 $response = $api->delete_customer('us@sendwithus.com');
 ```
 
-### Conversion on Customer
-Adds a conversion event to recent templates for recipient
-
-```php
-customer_conversion(
-    $email,             // string, email of customer
-    $revenue,           // integer, optional, amount in cents
-);
-```
-
-Example (required parameters only)
-
-```php
-$response = $api->customer_conversion('curtis@sendwithus.com');
-
-print_r($response);
-
-/*
-stdClass Object
-(
-    [status] => OK
-    [success] => 1
-)
-*/
-```
-
-Example (all parameters)
-
-```php
-// $19.99 in revenue
-$response = $api->customer_conversion('curtis@sendwithus.com', 1999);
-
-print_r($response);
-
-/*
-stdClass Object
-(
-    [status] => OK
-    [success] => 1
-)
-*/
-```
-
 ### List Customer Logs
 List all customer logs
 

--- a/lib/API.php
+++ b/lib/API.php
@@ -22,7 +22,7 @@ class API {
     protected $API_VERSION = '1';
     protected $API_HEADER_KEY = 'X-SWU-API-KEY';
     protected $API_HEADER_CLIENT = 'X-SWU-API-CLIENT';
-    protected $API_CLIENT_VERSION = "4.0.0";
+    protected $API_CLIENT_VERSION = "5.0.0";
     protected $API_CLIENT_STUB = "php-%s";
 
     protected $DEBUG = false;
@@ -226,21 +226,6 @@ class API {
     public function delete_customer($email) {
         $endpoint = "customers/" . $email;
         return $this->api_request($endpoint, self::HTTP_DELETE);
-    }
-
-    /**
-     * Customer Conversion
-     *
-     * @param string $email customer email
-     * @param array $revenue Optional revenue cent value
-     *
-     * @return array API response object.
-     */
-    public function customer_conversion($email, $revenue=null) {
-        $endpoint = "customers/" . $email . "/conversions";
-        $payload = array("revenue" => $revenue);
-
-        return $this->api_request($endpoint, self::HTTP_POST, $payload);
     }
 
     /**

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -384,7 +384,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
         /*
         * Author: Marie Starck on May 2nd, 2017
         * Sometimes the tests run too fast and the send executed in the setUp
-        * hasn't had time to be saved in database before testresend is executed.
+        * hasn't had time to be saved in database before testResend is executed.
         * This is to prevent this timing issue.
         */
         sleep(15);

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -459,20 +459,6 @@ class APITestCase extends PHPUnit_Framework_TestCase
         print 'Test delete customer';
     }
 
-    public function testCustomerConversion() {
-        $r = $this->api->customer_conversion($this->recipient['address']);
-        $this->assertSuccess($r);
-
-        print 'Test customer conversion';
-    }
-
-    public function testCustomerConversionRevenue() {
-        $r = $this->api->customer_conversion($this->recipient['address'], 1234);
-        $this->assertSuccess($r);
-
-        print 'Test customer conversion revenue';
-    }
-
     public function testListDripCampaigns(){
         $r = $this->api->list_drip_campaigns();
         $this->assertNotNull($r);


### PR DESCRIPTION
This PR deprecates the conversion feature from the PHP client for Sendwithus.

## Description
- Update README to reflect Conversion API changes as the feature will soon be deprecated from all clients.
- Remove Conversion API support from library

## Motivation and Context
This feature has been deprecated and will later be removed so we are updating the client to reflect this.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.