### PR TITLE
Update tests relying on old log-id

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,6 @@
         "classmap": ["lib"]
     },
     "require-dev": {
-    	"phpunit/phpunit": "3.7.*"
+    	"phpunit/phpunit": "^5.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,5 @@
     "description": "sendwithus.com PHP Client",
     "autoload": {
         "classmap": ["lib"]
-    },
-   //  "require-dev": {
-   //     "phpunit/phpunit": "^5.7"
-   // }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "autoload": {
         "classmap": ["lib"]
     },
-    "require": {
+    "require-dev": {
        "phpunit/phpunit": "^5.7"
    }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,9 @@
     "name": "sendwithus/api",
     "description": "sendwithus.com PHP Client",
     "autoload": {
-        "classmap": ["lib"],
-        "require-dev" : {"phpunit/phpunit":"3.7.*"}
+        "classmap": ["lib"]
+    },
+    "require-dev": {
+    	"phpunit/phpunit": "3.7.*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,5 +3,8 @@
     "description": "sendwithus.com PHP Client",
     "autoload": {
         "classmap": ["lib"]
-    }
+    },
+    "require": {
+       "phpunit/phpunit": "^5.7"
+   }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "sendwithus/api",
     "description": "sendwithus.com PHP Client",
     "autoload": {
-        "classmap": ["lib"]
+        "classmap": ["lib"],
+        "require-dev" : {"phpunit/phpunit":"3.7.*"}
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "autoload": {
         "classmap": ["lib"]
     },
-    "require-dev": {
-       "phpunit/phpunit": "^5.7"
-   }
+   //  "require-dev": {
+   //     "phpunit/phpunit": "^5.7"
+   // }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,5 @@
     "description": "sendwithus.com PHP Client",
     "autoload": {
         "classmap": ["lib"]
-    },
-    "require-dev": {
-    	"phpunit/phpunit": "^5.0"
     }
 }

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -362,8 +362,16 @@ class APITestCase extends \PHPUnit\Framework\TestCase
     }
 
     public function testResend(){
-        $r = $this->api->resend($this->log_id);
+        $send = $this->api->send(
+            $this->EMAIL_ID,
+            $this->recipient,
+            array("data" => $this->data)
+        );
+
+        $r = $this->api->resend($send->receipt_id);
         $this->assertSuccess($r);
+
+        print 'Test resend mail from log';
     }
 
     public function testResendFailed(){

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -387,7 +387,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
         * hasn't had time to be saved in database before testresend is executed.
         * This is to prevent this timing issue.
         */
-        sleep(10);
+        sleep(15);
 
         $r = $this->api->resend($this->log_id);
         $this->assertSuccess($r);

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -8,7 +8,7 @@ require_once(dirname(__FILE__) . '/../lib/API.php');
 require_once(dirname(__FILE__) . '/../lib/Error.php');
 // require_once 'PHPUnit/Autoload.php';
 
-class APITestCase extends \PHPUnit\Framework\TestCase
+class APITestCase extends PHPUnit_Framework_TestCase
 {
     private $API_KEY = 'THIS_IS_A_TEST_API_KEY';
     private $EMAIL_ID = 'test_fixture_1';

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -6,7 +6,7 @@
 
 require_once(dirname(__FILE__) . '/../lib/API.php');
 require_once(dirname(__FILE__) . '/../lib/Error.php');
-// require_once 'PHPUnit/Autoload.php';
+require_once 'PHPUnit/Autoload.php';
 
 class APITestCase extends PHPUnit_Framework_TestCase
 {

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -361,18 +361,18 @@ class APITestCase extends PHPUnit_Framework_TestCase
         print 'Simple bad send';
     }
 
-    public function testResend(){
-        $send = $this->api->send(
-            $this->EMAIL_ID,
-            $this->recipient,
-            array("data" => $this->data)
-        );
+    // public function testResend(){
+    //     $send = $this->api->send(
+    //         $this->EMAIL_ID,
+    //         $this->recipient,
+    //         array("data" => $this->data)
+    //     );
 
-        $r = $this->api->resend($send->receipt_id);
-        $this->assertSuccess($r);
+    //     $r = $this->api->resend($send->receipt_id);
+    //     $this->assertSuccess($r);
 
-        print 'Test resend mail from log';
-    }
+    //     print 'Test resend mail from log';
+    // }
 
     public function testResendFailed(){
         $r = $this->api->resend('i-do-not-exist-log-id');

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -88,7 +88,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
 
         $this->false_drip_campaign_id = 'false_drip_campaign_id';
 
-        $this->log_id = '130be975-dc07-4071-9333-58530e5df052-i03a5q';
+        $this->log_id = 'log_3bff29415746578d992ada6847b6ff08-3';
 
 
         $this->api->create_customer(
@@ -362,9 +362,14 @@ class APITestCase extends PHPUnit_Framework_TestCase
     }
 
     public function testResend(){
-        $r = $this->api->resend($this->log_id);
-        $this->assertSuccess($r);
+        $send = $this->api->send(
+            $this->EMAIL_ID,
+            $this->recipient,
+            array("data" => $this->data)
+        );
 
+        $r = $this->api->resend($send->receipt_id);
+        $this->assertSuccess($r);
         print 'Test resend mail from log';
     }
 

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -362,15 +362,8 @@ class APITestCase extends \PHPUnit\Framework\TestCase
     }
 
     public function testResend(){
-        $send = $this->api->send(
-            $this->EMAIL_ID,
-            $this->recipient,
-            array("data" => $this->data)
-        );
-
-        $r = $this->api->resend($send->receipt_id);
+        $r = $this->api->resend($this->log_id);
         $this->assertSuccess($r);
-        print 'Test resend mail from log';
     }
 
     public function testResendFailed(){

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -6,9 +6,9 @@
 
 require_once(dirname(__FILE__) . '/../lib/API.php');
 require_once(dirname(__FILE__) . '/../lib/Error.php');
-require_once 'PHPUnit/Autoload.php';
+// require_once 'PHPUnit/Autoload.php';
 
-class APITestCase extends PHPUnit_Framework_TestCase
+class APITestCase extends \PHPUnit\Framework\TestCase
 {
     private $API_KEY = 'THIS_IS_A_TEST_API_KEY';
     private $EMAIL_ID = 'test_fixture_1';

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -8,6 +8,16 @@ require_once(dirname(__FILE__) . '/../lib/API.php');
 require_once(dirname(__FILE__) . '/../lib/Error.php');
 // require_once 'PHPUnit/Autoload.php';
 
+
+/*
+* Author: Marie Starck on May 2nd, 2017
+*
+* For compabitlity with older PHP versions and PHP 7
+* PHP 7 uses PHPUnit 6 which only accepts \PHPUnit\Framework\TestCase
+* whereas older PHP versions use PHPUnit_Framework_TestCase
+* This allows both to work.
+* For more information: https://thephp.cc/news/2017/02/migrating-to-phpunit-6
+*/
 if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase')) {
   class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
 }
@@ -371,14 +381,6 @@ class APITestCase extends PHPUnit_Framework_TestCase
     }
 
     public function testResend(){
-        sleep(10);
-        // $send = $this->api->send(
-        //     $this->EMAIL_ID,
-        //     $this->recipient,
-        //     array("data" => $this->data)
-        // );
-
-        // $r = $this->api->resend($send->receipt_id);
         $r = $this->api->resend($this->log_id);
         $this->assertSuccess($r);
 

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -8,7 +8,6 @@ require_once(dirname(__FILE__) . '/../lib/API.php');
 require_once(dirname(__FILE__) . '/../lib/Error.php');
 // require_once 'PHPUnit/Autoload.php';
 
-
 class APITestCase extends PHPUnit_Framework_TestCase
 {
     private $API_KEY = 'THIS_IS_A_TEST_API_KEY';
@@ -363,13 +362,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
     }
 
     public function testResend(){
-        $send = $this->api->send(
-            $this->EMAIL_ID,
-            $this->recipient,
-            array("data" => $this->data)
-        );
-
-        $r = $this->api->resend($send->receipt_id);
+        $r = $this->api->resend($this->log_id);
         $this->assertSuccess($r);
 
         print 'Test resend mail from log';

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -8,6 +8,10 @@ require_once(dirname(__FILE__) . '/../lib/API.php');
 require_once(dirname(__FILE__) . '/../lib/Error.php');
 // require_once 'PHPUnit/Autoload.php';
 
+if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase')) {
+  class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
+}
+
 class APITestCase extends PHPUnit_Framework_TestCase
 {
     private $API_KEY = 'THIS_IS_A_TEST_API_KEY';

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -8,7 +8,8 @@ require_once(dirname(__FILE__) . '/../lib/API.php');
 require_once(dirname(__FILE__) . '/../lib/Error.php');
 // require_once 'PHPUnit/Autoload.php';
 
-class APITestCase extends \PHPUnit\Framework\TestCase
+
+class APITestCase extends PHPUnit_Framework_TestCase
 {
     private $API_KEY = 'THIS_IS_A_TEST_API_KEY';
     private $EMAIL_ID = 'test_fixture_1';

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -381,6 +381,14 @@ class APITestCase extends PHPUnit_Framework_TestCase
     }
 
     public function testResend(){
+        /*
+        * Author: Marie Starck on May 2nd, 2017
+        * Sometimes the tests run too fast and the send executed in the setUp
+        * hasn't had time to be saved in database before testresend is executed.
+        * This is to prevent this timing issue.
+        */
+        sleep(10);
+
         $r = $this->api->resend($this->log_id);
         $this->assertSuccess($r);
 

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -8,6 +8,7 @@ require_once(dirname(__FILE__) . '/../lib/API.php');
 require_once(dirname(__FILE__) . '/../lib/Error.php');
 // require_once 'PHPUnit/Autoload.php';
 
+
 class APITestCase extends PHPUnit_Framework_TestCase
 {
     private $API_KEY = 'THIS_IS_A_TEST_API_KEY';

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -8,7 +8,7 @@ require_once(dirname(__FILE__) . '/../lib/API.php');
 require_once(dirname(__FILE__) . '/../lib/Error.php');
 // require_once 'PHPUnit/Autoload.php';
 
-class APITestCase extends PHPUnit_Framework_TestCase
+class APITestCase extends \PHPUnit\Framework\TestCase
 {
     private $API_KEY = 'THIS_IS_A_TEST_API_KEY';
     private $EMAIL_ID = 'test_fixture_1';
@@ -88,13 +88,18 @@ class APITestCase extends PHPUnit_Framework_TestCase
 
         $this->false_drip_campaign_id = 'false_drip_campaign_id';
 
-        $this->log_id = 'log_3bff29415746578d992ada6847b6ff08-3';
-
-
         $this->api->create_customer(
             $this->recipient['address'],
             array("data" => $this->data)
         );
+
+        $send = $this->api->send(
+            $this->EMAIL_ID,
+            $this->recipient,
+            array("data" => $this->data)
+        );
+
+        $this->log_id = $send->receipt_id;
     }
 
     function tearDown() {
@@ -361,18 +366,20 @@ class APITestCase extends PHPUnit_Framework_TestCase
         print 'Simple bad send';
     }
 
-    // public function testResend(){
-    //     $send = $this->api->send(
-    //         $this->EMAIL_ID,
-    //         $this->recipient,
-    //         array("data" => $this->data)
-    //     );
+    public function testResend(){
+        sleep(10);
+        // $send = $this->api->send(
+        //     $this->EMAIL_ID,
+        //     $this->recipient,
+        //     array("data" => $this->data)
+        // );
 
-    //     $r = $this->api->resend($send->receipt_id);
-    //     $this->assertSuccess($r);
+        // $r = $this->api->resend($send->receipt_id);
+        $r = $this->api->resend($this->log_id);
+        $this->assertSuccess($r);
 
-    //     print 'Test resend mail from log';
-    // }
+        print 'Test resend mail from log';
+    }
 
     public function testResendFailed(){
         $r = $this->api->resend('i-do-not-exist-log-id');

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -8,7 +8,6 @@ require_once(dirname(__FILE__) . '/../lib/API.php');
 require_once(dirname(__FILE__) . '/../lib/Error.php');
 // require_once 'PHPUnit/Autoload.php';
 
-
 class APITestCase extends PHPUnit_Framework_TestCase
 {
     private $API_KEY = 'THIS_IS_A_TEST_API_KEY';

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -362,7 +362,13 @@ class APITestCase extends PHPUnit_Framework_TestCase
     }
 
     public function testResend(){
-        $r = $this->api->resend($this->log_id);
+        $send = $this->api->send(
+            $this->EMAIL_ID,
+            $this->recipient,
+            array("data" => $this->data)
+        );
+
+        $r = $this->api->resend($send->receipt_id);
         $this->assertSuccess($r);
 
         print 'Test resend mail from log';


### PR DESCRIPTION
## Description
A couple tests relied on checking an old log-id. Those tests in question
will no longer return valid logs (that have been cleaned from our
system) and so the logs need to be updated

- Change the "resend email" test to send an email then verify the resend
  based on the first sent email returned log (rather than a hardcoded
  val)

## Motivation and Context
This fixes some of our tests!

## How Has This Been Tested?
Now the tests run correctly!

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Testing works again

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
