### PR TITLE
[Issue #77] Added priority levels to log handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ require_once 'vendor/autoload.php';
 $API_KEY = 'THIS_IS_A_TEST_API_KEY';
 $options = array(
     'DEBUG' => true,
-    'API_DEBUG_HANDLER' => function ($message) {
-        error_log('[SendWithUs][Debug] ' . $message);
+    'API_DEBUG_HANDLER' => function ($message, $priority_level) {
+        // possible priority levels - http://php.net/manual/en/function.syslog.php
+        error_log("[SendWithUs][$priority_level] " . $message);
     }
 );
 

--- a/lib/API.php
+++ b/lib/API.php
@@ -15,6 +15,9 @@ class API {
     const HTTP_PUT = 'PUT';
     const HTTP_DELETE = 'DELETE';
 
+    const LOG_ERR    = 'ERR';
+    const LOG_DEBUG  = 'DEBUG';
+
     protected $API_KEY = 'THIS_IS_A_TEST_API_KEY';
     protected $API_HOST = 'api.sendwithus.com';
     protected $API_PORT = '443';
@@ -595,8 +598,8 @@ class API {
             }
         } catch (API_Error $e) {
             if ($this->DEBUG) {
-                $this->log_message(sprintf("Caught exception: %s\r\n", $e->getMessage()));
-                $this->log_message(print_r($e, true));
+                $this->log_message(sprintf("Caught exception: %s\r\n", $e->getMessage()), self::LOG_ERR);
+                $this->log_message(print_r($e, true), self::LOG_ERR);
             }
 
             $response = (object) array(
@@ -617,16 +620,17 @@ class API {
      * If not handler is defined it falls back to using 'error_log'.
      *
      * @param $message string the logged message
+     * @param string $priority_level based on syslog priority levels http://php.net/manual/en/function.syslog.php
      * @return bool true on success or false on failure
      */
-    protected function log_message($message)
+    protected function log_message($message, $priority_level = self::LOG_DEBUG)
     {
         if (
             $this->DEBUG &&
             $this->API_DEBUG_HANDLER &&
             is_callable($this->API_DEBUG_HANDLER)
         ) {
-            $response = call_user_func($this->API_DEBUG_HANDLER, $message);
+            $response = call_user_func($this->API_DEBUG_HANDLER, $message, $priority_level);
         } else {
             $response = error_log($message);
         }
@@ -719,8 +723,8 @@ class BatchAPI extends API {
             }
         } catch (API_Error $e) {
             if ($this->DEBUG) {
-                $this->log_message(sprintf("Caught exception: %s\r\n", $e->getMessage()));
-                $this->log_message(print_r($e, true));
+                $this->log_message(sprintf("Caught exception: %s\r\n", $e->getMessage()), self::LOG_ERR);
+                $this->log_message(print_r($e, true), self::LOG_ERR);
             }
 
             $response = (object) array(


### PR DESCRIPTION
Added priority levels to log handler

## Description
Similar to the way syslog does it, I've added priority levels to the log_message function.
This will give the end user more flexibility when using the custom log handler.
Also, the logs which catch exceptions have been bumped to 'error' level.

## Motivation and Context
Resolves issue #77 

## How Has This Been Tested?
This has been tested manually using the custom log handler and outputting the priority level along the message.

## Types of changes
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X ] All new and existing tests passed.
