### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/test/APITest.php
+++ b/test/APITest.php
@@ -534,7 +534,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
 
     public function testGetBadCustomerLogs(){
         $logs = $this->api->get_customer_logs($this->bad_email);
-        $this->assertEquals(True, empty($logs->logs));
+        $this->assertEquals(true, empty($logs->logs));
 
         print 'Test retrieving non-existant customer logs';
     }


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!