### PR TITLE
Add optional preheader and AMP fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ lib/.DS_Store
 test/.DS_Store
 *.swo
 *.swp
+vendor

--- a/composer.json
+++ b/composer.json
@@ -3,5 +3,8 @@
     "description": "sendwithus.com PHP Client",
     "autoload": {
         "classmap": ["lib"]
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
     }
 }

--- a/lib/API.php
+++ b/lib/API.php
@@ -244,9 +244,11 @@ class API {
      * @param string $subject subject line for the email template
      * @param string $html HTML code for the email template
      * @param string $text Optional text version of the email template
+     * @param string $preheader Optional preheader for the email template
+     * @param string $amp_html Optional AMP version of the email template
      * @return array API response object
      */
-    public function create_email($name, $subject, $html, $text=null) {
+    public function create_email($name, $subject, $html, $text=null, $preheader=null, $amp_html=null) {
         $endpoint = "templates";
 
         $payload = array(
@@ -255,9 +257,15 @@ class API {
             "html" => $html
         );
 
-        // set optional text
+        // set optionals
         if ($text) {
             $payload["text"] = $text;
+        }
+        if (!is_null($preheader)) {
+            $payload["preheader"] = $preheader;
+        }
+        if (!is_null($amp_html)) {
+            $payload["amp_html"] = $amp_html;
         }
 
         if ($this->DEBUG) {
@@ -274,9 +282,11 @@ class API {
      * @param string $template_id template id
      * @param string $html HTML code for the email template
      * @param string $text Optional text version of the email template
+     * @param string $preheader Optional preheader for the email template
+     * @param string $amp_html Optional AMP version of the email template
      * @return array API response object
      */
-    public function create_new_template_version($name, $subject, $template_id, $html, $text=null) {
+    public function create_new_template_version($name, $subject, $template_id, $html, $text=null, $preheader=null, $amp_html=null) {
         $endpoint = "templates/" . $template_id . "/versions";
 
         $payload = array(
@@ -285,9 +295,15 @@ class API {
             "html" => $html
         );
 
-        // set optional text
+        // set optionals
         if ($text) {
             $payload["text"] = $text;
+        }
+        if (!is_null($preheader)) {
+            $payload["preheader"] = $preheader;
+        }
+        if (!is_null($amp_html)) {
+            $payload["amp_html"] = $amp_html;
         }
 
         if ($this->DEBUG) {
@@ -307,9 +323,11 @@ class API {
      * @param string $version_id template version id
      * @param string $html HTML code for the email template
      * @param string $text Optional text version of the email template
+     * @param string $preheader Optional preheader for the email template
+     * @param string $amp_html Optional AMP version of the email template
      * @return array API response object
      */
-    public function update_template_version($name, $subject, $template_id, $version_id, $html, $text=null) {
+    public function update_template_version($name, $subject, $template_id, $version_id, $html, $text=null, $preheader=null, $amp_html=null) {
         $endpoint = "templates/" . $template_id . "/versions/" . $version_id;
 
         $payload = array(
@@ -318,9 +336,15 @@ class API {
             "html" => $html
         );
 
-        // set optional text
+        // set optionals
         if ($text) {
             $payload["text"] = $text;
+        }
+        if (!is_null($preheader)) {
+            $payload["preheader"] = $preheader;
+        }
+        if (!is_null($amp_html)) {
+            $payload["amp_html"] = $amp_html;
         }
 
         if ($this->DEBUG) {

--- a/lib/API.php
+++ b/lib/API.php
@@ -25,7 +25,7 @@ class API {
     protected $API_VERSION = '1';
     protected $API_HEADER_KEY = 'X-SWU-API-KEY';
     protected $API_HEADER_CLIENT = 'X-SWU-API-CLIENT';
-    protected $API_CLIENT_VERSION = "6.3.0";
+    protected $API_CLIENT_VERSION = "6.4.0";
     protected $API_CLIENT_STUB = "php-%s";
     protected $API_DEBUG_HANDLER = null;
 

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -22,14 +22,14 @@ if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Frame
   class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
 }
 
-class APITestCase extends PHPUnit_Framework_TestCase
+class APITest extends PHPUnit_Framework_TestCase
 {
-    private $API_KEY = 'PHP_API_CLIENT_TEST_KEY';
-    private $EMAIL_ID = 'test_fixture_1';
 
     private $options = null;
 
     /** @var \sendwithus\API  */
+    private $api_key = null;
+    private $email_id = null;
     private $api = null;
     private $recipient = null;
     private $incompleteRecepient = null;
@@ -39,13 +39,16 @@ class APITestCase extends PHPUnit_Framework_TestCase
     private $bcc = null;
 
 
-    function setUp() {
+    function setUp(): void{
+
+        $this->api_key = getenv('SWU_API_KEY') ?: 'PHP_API_CLIENT_TEST_KEY';
+        $this->email_id = getenv('TEMPLATE_ID') ?: 'test_fixture_1';
 
         $this->options = array(
             'DEBUG' => false
         );
 
-        $this->api = new \sendwithus\API($this->API_KEY, $this->options);
+        $this->api = new \sendwithus\API($this->api_key, $this->options);
 
         $this->good_html = '<html><head></head><body></body></html>';
 
@@ -88,15 +91,15 @@ class APITestCase extends PHPUnit_Framework_TestCase
 
         $this->tags = array('tag_one', 'tag_two');
 
-        $this->template_id = 'pmaBsiatWCuptZmojWESme';
+        $this->template_id = getenv('TEMPLATE_ID') ?: 'pmaBsiatWCuptZmojWESme';
 
-        $this->version_id = 'ver_pYj27c8DTBsWB4MRsoB2MF';
+        $this->version_id = getenv('VERSION_ID') ?: 'ver_pYj27c8DTBsWB4MRsoB2MF';
 
-        $this->enabled_drip_campaign_id = 'dc_Rmd7y5oUJ3tn86sPJ8ESCk';
+        $this->enabled_drip_campaign_id = getenv('DRIP_CAMPAIGN_ID') ?: 'dc_Rmd7y5oUJ3tn86sPJ8ESCk';
 
-        $this->enabled_drip_campaign_step_id = 'dcs_yaAMiZNWCLAEGw7GLjBuGY';
+        $this->enabled_drip_campaign_step_id = getenv('DRIP_CAMPAIGN_STEP_ID') ?: 'dcs_yaAMiZNWCLAEGw7GLjBuGY';
 
-        $this->disabled_drip_campaign_id = 'dc_AjR6Ue9PHPFYmEu2gd8x5V';
+        $this->disabled_drip_campaign_id = getenv('DRIP_CAMPAIGN_DISABLED_ID') ?: 'dc_AjR6Ue9PHPFYmEu2gd8x5V';
 
         $this->false_drip_campaign_id = 'false_drip_campaign_id';
 
@@ -105,10 +108,10 @@ class APITestCase extends PHPUnit_Framework_TestCase
             array("data" => $this->data)
         );
 
-        $this->log_id = 'log_152fea9a9673c4acff249d5778b3ccef-3';
+        $this->log_id = getenv('LOG_ID') ?: 'log_152fea9a9673c4acff249d5778b3ccef-3';
     }
 
-    function tearDown() {
+    function tearDown(): void {
         $this->api->create_customer(
             $this->recipient['address'],
             array("data" => $this->data)
@@ -175,7 +178,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
 
     public function testSimpleSend() {
         $r = $this->api->send(
-            $this->EMAIL_ID,
+            $this->email_id,
             $this->recipient,
             array("data" => $this->data)
         );
@@ -187,7 +190,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
 
     public function testSendWithEmptyData() {
         $r = $this->api->send(
-            $this->EMAIL_ID,
+            $this->email_id,
             $this->recipient,
             array("data" => array())
         );
@@ -199,7 +202,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
 
     public function testSendWithNullData() {
         $r = $this->api->send(
-            $this->EMAIL_ID,
+            $this->email_id,
             $this->recipient,
             array("data" => null)
         );
@@ -211,7 +214,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
 
     public function testSendWithSender() {
         $r = $this->api->send(
-            $this->EMAIL_ID,
+            $this->email_id,
             $this->recipient,
             array(
                 "data" => $this->data,
@@ -226,7 +229,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
 
     public function testSendWithCC() {
         $r = $this->api->send(
-            $this->EMAIL_ID,
+            $this->email_id,
             $this->recipient,
             array(
                 "data" => $this->data,
@@ -241,7 +244,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
 
     public function testSendWithBCC() {
         $r = $this->api->send(
-            $this->EMAIL_ID,
+            $this->email_id,
             $this->recipient,
             array(
                 "data" => $this->data,
@@ -256,7 +259,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
 
     public function testSendWithInline() {
         $r = $this->api->send(
-            $this->EMAIL_ID,
+            $this->email_id,
             $this->recipient,
             array(
                 "data" => $this->data,
@@ -271,7 +274,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
 
     public function testSendWithInlineEncoded() {
         $r = $this->api->send(
-            $this->EMAIL_ID,
+            $this->email_id,
             $this->recipient,
             array(
                 "data" => $this->data,
@@ -289,7 +292,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
 
     public function testSendWithFiles() {
         $r = $this->api->send(
-            $this->EMAIL_ID,
+            $this->email_id,
             $this->recipient,
             array(
                 "data" => $this->data,
@@ -316,7 +319,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
         );
 
         $r = $this->api->send(
-            $this->EMAIL_ID,
+            $this->email_id,
             $this->recipient,
             array(
                 "data" => $this->data,
@@ -331,7 +334,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
 
     public function testSendWithTags() {
         $r = $this->api->send(
-            $this->EMAIL_ID,
+            $this->email_id,
             $this->recipient,
             array(
                 "data" => $this->data,
@@ -346,7 +349,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
 
     public function testSendIncomplete() {
         $r = $this->api->send(
-            $this->EMAIL_ID,
+            $this->email_id,
             $this->incompleteRecipient,
             array(
                 "data" => $this->data,
@@ -378,7 +381,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
         $api = new \sendwithus\API('INVALID_API_KEY', $this->options);
 
         $r = $api->send(
-            $this->EMAIL_ID,
+            $this->email_id,
             $this->recipient,
             array("data" => $this->data)
         );
@@ -405,7 +408,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
 
     public function testRender() {
         $r = $this->api->render(
-            $this->EMAIL_ID,
+            $this->email_id,
             array("data" => $this->data)
         );
 
@@ -540,7 +543,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
     }
 
     public function testBatchConstructor() {
-        $batch = new \sendwithus\BatchAPI($this->API_KEY, $this->options);
+        $batch = new \sendwithus\BatchAPI($this->api_key, $this->options);
         $this->assertNotEmpty($batch);
     }
 
@@ -624,7 +627,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
             }
         );
 
-        $api = new \sendwithus\API($this->API_KEY, $options);
+        $api = new \sendwithus\API($this->api_key, $options);
         $result = $method->invoke($api, 'test message');
 
         $this->assertTrue($result);
@@ -642,7 +645,7 @@ class APITestCase extends PHPUnit_Framework_TestCase
             }
         );
 
-        $api = new \sendwithus\API($this->API_KEY, $options);
+        $api = new \sendwithus\API($this->api_key, $options);
         $result = $method->invoke($api, 'test message');
 
         $this->assertFalse($result);

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -146,7 +146,9 @@ class APITest extends PHPUnit_Framework_TestCase
         $r = $this->api->create_email(
             'test name',
             'test subject',
-            $this->good_html
+            $this->good_html,
+	    null,
+	    'test preheader'
         );
 
         $this->assertNotNull($r);
@@ -158,7 +160,9 @@ class APITest extends PHPUnit_Framework_TestCase
             'test name '.time(),
             'test subject',
             $this->template_id,
-            $html=$this->good_html
+            $html=$this->good_html,
+	    null,
+	    'test preheader'
         );
         $this->assertNotNull($r->created);
         print "Created a new template version";
@@ -170,10 +174,25 @@ class APITest extends PHPUnit_Framework_TestCase
             'test subject',
             $this->template_id,
             $this->version_id,
-            $this->good_html
+            $this->good_html,
+	    null,
+	    'test preheader'
         );
         $this->assertNotNull($r->created);
         print "Updated a template version";
+    }
+
+    public function testGetTemplate(){
+        $r = $this->api->get_template(
+            $this->template_id,
+	    $this->version_id
+        );
+        $this->assertEquals($r->id, $this->version_id);
+        $this->assertNotNull($r->created);
+        $this->assertNotNull($r->subject);
+        $this->assertNotNull($r->html);
+        $this->assertNotNull($r->preheader);
+        print 'Get template version';
     }
 
     public function testSimpleSend() {


### PR DESCRIPTION
Add support for `preheader` and `amp_html` optional fields for template operations

## Description
<!--- Describe your changes in detail if necessary -->
* Add `preheader` and `amp_html` to `create_email`, `create_new_template_version` and `update_template_version`
* Fixed some test class issues, allow overriding hardcoded resource IDs in test cases

## Motivation and Context
Parity with the current Sendwithus API
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
* All test pass
* Created a test consumer to verify all affected operations work as expected against test and production environments
* `amp_html` not yet GA, omitted from test cases
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
