### PR TITLE
Updates README to not use Github for package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,8 @@ Install it via Composer
 Add it to your composer.json
 ```json
 {
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/sendwithus/sendwithus_php"
-        }
-    ],
     "require": {
-        "sendwithus/api": "dev-master"
+        "sendwithus/api": "^6.4"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -6,5 +6,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"
-    }
+    },
+    "license": "Apache-2.0"
 }


### PR DESCRIPTION
Update the README and add a license to the `composer.json` so the license is shown on packagist.
